### PR TITLE
アセットパスの指定に asdf:system-source-directory を使う。

### DIFF
--- a/src/define.lisp
+++ b/src/define.lisp
@@ -39,7 +39,7 @@
 (defparameter *save3-day* nil)
 
 
-(gk:register-resource-package :keyword "../assets/")
+(gk:register-resource-package :keyword (merge-pathnames "assets/" (asdf:system-source-directory :lowmogecage)))
 
 
 (gk:define-font :mplus "font/mplus-1mn-regular.ttf")


### PR DESCRIPTION
アセットディレクトリの指定が `./assets/` から `../assets/` に変わりましたが、そうするとビルドスクリプトも src/ ディレクトリから実行しないといけません。

Emacsでソースコードを開いたバッファーで Lisp を起動すると作業ディレクトリが src/ になることが、`../assets` に変更された理由だと思うのですが、`asdf:system-source-directory` 関数を使えばプロジェクトディレクトリでCommon Lispを起動しても、srcディレクトリでCommon Lispを起動しても正しくアセットディレクトリが参照できます。

どうでしょう。